### PR TITLE
Remove user IDs from rate limiting whitelist in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ bot:
   rate_limit:
     hourly_limit: 5  # Maximum number of requests per hour per user
     daily_limit: 15  # Maximum number of requests per day per user
-    whitelist_ids: [816297198] # List of user IDs exempt from rate limiting
+    whitelist_ids: [] # List of user IDs exempt from rate limiting
 
 ai:
   model: "claude-3-5-sonnet-20241022" # Anthropic model to use


### PR DESCRIPTION
Eliminate all user IDs from the rate limiting whitelist to enhance security and ensure consistent rate limiting for all users.