### PR TITLE
Add Makefile for build, test, lint, and mocks commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test lint mocks
+
+test:
+	go test --race ./...
+
+lint:
+	golangci-lint run
+
+mocks:
+	mockery
+
+deploy:
+	git pull && docker-compose pull && docker stack deploy -c docker-compose.yml app


### PR DESCRIPTION
Introduce a Makefile to streamline build, testing, linting, and mock generation processes.