### PR TITLE
Add /terms command to display Terms and Conditions

### DIFF
--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -49,6 +49,10 @@ func (s *ServiceImpl) Handle(ctx context.Context, msg *tgbotapi.Message) (tgbota
 	// Handle /start command
 	if msg.Text == "/start" {
 		return tgbotapi.NewMessage(msg.Chat.ID, s.Messages.GetMessage(msg.From.LanguageCode, i18n.StartMessage)), nil
+	} else if msg.Text == "/terms" {
+		msg := tgbotapi.NewMessage(msg.Chat.ID, termsContent)
+		msg.ParseMode = "HTML"
+		return msg, nil
 	}
 
 	request, err := core.NewUserMessage(

--- a/pkg/bot/terms.go
+++ b/pkg/bot/terms.go
@@ -1,0 +1,46 @@
+package bot
+
+const termsContent = `<b>Terms and Conditions</b>
+<i>Last updated: 30.01.2025</i>
+
+Thank you for using our veterinary advice chatbot (“the Service”). By accessing or using this Service, you agree to be bound by the following terms and conditions (“Terms”). If you do not agree to these Terms, please discontinue use immediately.
+
+<b>1. Nature of the Service</b>
+1.1 The Service provides general information, guidance, and suggestions for pet care, including (but not limited to) diet, behavior, and training.
+1.2 The Service is not a substitute for professional veterinary diagnosis, treatment, or care. Always seek the advice of a licensed veterinarian for any questions regarding your pet’s health.
+
+<b>2. No Veterinary-Client-Patient Relationship</b>
+2.1 Using the Service or engaging with our AI assistant does not create a veterinarian-client-patient relationship.
+2.2 Any advice or guidance provided by the Service is based on limited information and should only be considered general information.
+
+<b>3. Limitation of Liability</b>
+3.1 You acknowledge and agree that use of the Service is at your own risk.
+3.2 Under no circumstances shall the owners, developers, or licensors of the Service be liable for any direct, indirect, incidental, special, or consequential damages arising out of or in connection with your access to or use of the Service.
+3.3 You understand that decisions regarding your pet’s care and any resulting outcomes are your sole responsibility. If you have any doubt about the well-being of your pet or its health, you should immediately consult a licensed veterinarian.
+
+<b>4. No Warranty</b>
+4.1 The Service is provided on an “as is” and “as available” basis without warranties of any kind, whether express or implied.
+4.2 We do not warrant that the Service will be uninterrupted, error-free, secure, or free from viruses.
+
+<b>5. User Responsibilities</b>
+5.1 You are responsible for providing accurate and complete information about your pet when seeking advice.
+5.2 You must ensure that all questions, descriptions, and data you provide do not violate any third-party rights or local laws.
+
+<b>6. International Use</b>
+6.1 The Service is intended for global use. You are responsible for compliance with all applicable local laws and regulations in your jurisdiction.
+6.2 We do not guarantee that the Service or any of its content is appropriate or permissible in any specific country or region.
+
+<b>7. Modifications</b>
+7.1 We reserve the right to modify or replace these Terms at any time.
+7.2 If we make material changes, we will post the updated Terms and indicate the date of the latest revision at the top of this document.
+
+<b>8. Governing Law and Dispute Resolution</b>
+8.1 These Terms shall be governed by and construed in accordance with the laws applicable in the jurisdiction of the Service provider’s principal place of business, without regard to conflict-of-law principles.
+8.2 Any dispute arising from or relating to these Terms shall be resolved through amicable negotiation and, if necessary, by binding arbitration or litigation in the applicable courts.
+
+<b>9. Acceptance of Terms</b>
+9.1 By continuing to access or use the Service, you acknowledge that you have read, understood, and agree to be bound by these Terms.
+9.2 If you do not agree, you must cease using the Service immediately.
+
+If you have any questions or concerns regarding these Terms, or if you need further clarification, please contact at <i>k.sysoev@me.com</i>.
+`


### PR DESCRIPTION
### Description
This pull request introduces a new `/terms` command to the chatbot, which displays the service's Terms and Conditions in HTML format. These terms provide essential information on user responsibilities, service guidelines, and liability limitations. This addition enhances transparency and aligns with user agreement compliance. 
