### PR TITLE
Enable HTML parsing for bot responses

### DIFF
--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -81,6 +81,7 @@ func (s *ServiceImpl) Handle(ctx context.Context, msg *tgbotapi.Message) (tgbota
 
 	// Create msg with buttons if available
 	resp := tgbotapi.NewMessage(msg.Chat.ID, response.Message)
+	resp.ParseMode = "HTML"
 
 	// Handle keyboard markup based on answers
 	if len(response.Answers) > 0 {

--- a/pkg/prov/anthropic/output_parser.go
+++ b/pkg/prov/anthropic/output_parser.go
@@ -41,6 +41,7 @@ Note:
 - The "questions" array is optional and can be empty if no follow-up questions are needed
 - Each question must have a "text" field
 - The "answers" field in questions is optional
+- The "text" field supports these html tags: <b>bold</b>, <i>italic</i>, <u>underline</u>, <s>strikethrough</s>, and following html entities: &lt;, &gt;, &amp; and &quot;.
 
 Example with no questions:
 {


### PR DESCRIPTION
### Description of Changes

- Enabled parsing of HTML in bot responses with `ParseMode` set to "HTML".
- Updated documentation to clarify which HTML tags and entities are supported.
- Enhanced message formatting options for better user communication.
