### PR TITLE
Add validation for answer length in follow-up questionnaire

### DIFF
--- a/pkg/core/conversation/conversation.go
+++ b/pkg/core/conversation/conversation.go
@@ -13,7 +13,8 @@ import (
 type ConversationState string
 
 const (
-	MaxMessageHistory = 5 // Maximum number of messages to keep in history
+	MaxMessageHistory = 5   // Maximum number of messages to keep in history
+	MaxAnswerLength   = 200 // Maximum length of an answer
 
 	StateNormal                ConversationState = "normal"
 	StateFollowUpQuestioning   ConversationState = "questioning" // Used for LLM questionnaire (backward compatibility)

--- a/pkg/core/conversation/followup.go
+++ b/pkg/core/conversation/followup.go
@@ -1,6 +1,10 @@
 package conversation
 
-import "github.com/ksysoev/help-my-pet/pkg/core/message"
+import (
+	"unicode/utf8"
+
+	"github.com/ksysoev/help-my-pet/pkg/core/message"
+)
 
 // FollowUpQuestionnaireState represents the state for follow-up questions from LLM
 type FollowUpQuestionnaireState struct {
@@ -35,6 +39,10 @@ func (f *FollowUpQuestionnaireState) GetCurrentQuestion() (*message.Question, er
 func (f *FollowUpQuestionnaireState) ProcessAnswer(answer string) (bool, error) {
 	if f.CurrentIndex >= len(f.QAPairs) {
 		return false, ErrNoMoreQuestions
+	}
+
+	if utf8.RuneCountInString(answer) > MaxAnswerLength {
+		return false, message.ErrTextTooLong
 	}
 
 	f.QAPairs[f.CurrentIndex].Answer = answer

--- a/pkg/core/conversation/followup_test.go
+++ b/pkg/core/conversation/followup_test.go
@@ -217,3 +217,22 @@ func TestFollowUpQuestionnaire_ProcessAnswer(t *testing.T) {
 		})
 	}
 }
+
+func TestFollowUpQuestionnaire_ProcessAnswer_TooLongAnswer(t *testing.T) {
+	lognAnswer := `
+	This is a very long answer that is longer than the maximum allowed length
+	This is a very long answer that is longer than the maximum allowed length
+	This is a very long answer that is longer than the maximum allowed length
+`
+
+	// Arrange
+	state := NewFollowUpQuestionnaireState("Initial Prompt", []message.Question{{Text: "What is your name?"}})
+
+	// Act
+	done, err := state.ProcessAnswer(lognAnswer)
+
+	// Assert
+	assert.ErrorIs(t, err, message.ErrTextTooLong, "error should be ErrTextTooLong")
+	assert.False(t, done, "done should be false")
+	assert.Equal(t, 0, state.CurrentIndex, "current index should not be incremented")
+}


### PR DESCRIPTION
This Pull Request introduces enhancements and validations to the Conversation and FollowUpQuestionnaireState components, aiming to improve the robustness of conversations and questionnaire handling.

- Added a MaxAnswerLength constant to limit the length of answers to 200 characters.
- Integrated length validation for answers within the ProcessAnswer method in followup.go.
- Enhanced unit tests to cover scenarios for overly long answers in followup_test.go.
- Minor cleanups and additional import optimizations to enforce coding standards and package structure.