### PR TITLE
Add conversation reset functionality

### DIFF
--- a/pkg/bot/ai_provider_mock.go
+++ b/pkg/bot/ai_provider_mock.go
@@ -24,6 +24,53 @@ func (_m *MockAIProvider) EXPECT() *MockAIProvider_Expecter {
 	return &MockAIProvider_Expecter{mock: &_m.Mock}
 }
 
+// CancelQuestionnaire provides a mock function with given fields: ctx, chatID
+func (_m *MockAIProvider) CancelQuestionnaire(ctx context.Context, chatID string) error {
+	ret := _m.Called(ctx, chatID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CancelQuestionnaire")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, chatID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockAIProvider_CancelQuestionnaire_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CancelQuestionnaire'
+type MockAIProvider_CancelQuestionnaire_Call struct {
+	*mock.Call
+}
+
+// CancelQuestionnaire is a helper method to define mock.On call
+//   - ctx context.Context
+//   - chatID string
+func (_e *MockAIProvider_Expecter) CancelQuestionnaire(ctx interface{}, chatID interface{}) *MockAIProvider_CancelQuestionnaire_Call {
+	return &MockAIProvider_CancelQuestionnaire_Call{Call: _e.mock.On("CancelQuestionnaire", ctx, chatID)}
+}
+
+func (_c *MockAIProvider_CancelQuestionnaire_Call) Run(run func(ctx context.Context, chatID string)) *MockAIProvider_CancelQuestionnaire_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockAIProvider_CancelQuestionnaire_Call) Return(_a0 error) *MockAIProvider_CancelQuestionnaire_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockAIProvider_CancelQuestionnaire_Call) RunAndReturn(run func(context.Context, string) error) *MockAIProvider_CancelQuestionnaire_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ProcessEditProfile provides a mock function with given fields: ctx, request
 func (_m *MockAIProvider) ProcessEditProfile(ctx context.Context, request *message.UserMessage) (*message.Response, error) {
 	ret := _m.Called(ctx, request)
@@ -138,53 +185,6 @@ func (_c *MockAIProvider_ProcessMessage_Call) Return(_a0 *message.Response, _a1 
 }
 
 func (_c *MockAIProvider_ProcessMessage_Call) RunAndReturn(run func(context.Context, *message.UserMessage) (*message.Response, error)) *MockAIProvider_ProcessMessage_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ResetConversation provides a mock function with given fields: ctx, chatID
-func (_m *MockAIProvider) ResetConversation(ctx context.Context, chatID string) error {
-	ret := _m.Called(ctx, chatID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ResetConversation")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, chatID)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockAIProvider_ResetConversation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetConversation'
-type MockAIProvider_ResetConversation_Call struct {
-	*mock.Call
-}
-
-// ResetConversation is a helper method to define mock.On call
-//   - ctx context.Context
-//   - chatID string
-func (_e *MockAIProvider_Expecter) ResetConversation(ctx interface{}, chatID interface{}) *MockAIProvider_ResetConversation_Call {
-	return &MockAIProvider_ResetConversation_Call{Call: _e.mock.On("ResetConversation", ctx, chatID)}
-}
-
-func (_c *MockAIProvider_ResetConversation_Call) Run(run func(ctx context.Context, chatID string)) *MockAIProvider_ResetConversation_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockAIProvider_ResetConversation_Call) Return(_a0 error) *MockAIProvider_ResetConversation_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockAIProvider_ResetConversation_Call) RunAndReturn(run func(context.Context, string) error) *MockAIProvider_ResetConversation_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/bot/ai_provider_mock.go
+++ b/pkg/bot/ai_provider_mock.go
@@ -142,6 +142,53 @@ func (_c *MockAIProvider_ProcessMessage_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// ResetConversation provides a mock function with given fields: ctx, chatID
+func (_m *MockAIProvider) ResetConversation(ctx context.Context, chatID string) error {
+	ret := _m.Called(ctx, chatID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResetConversation")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, chatID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockAIProvider_ResetConversation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetConversation'
+type MockAIProvider_ResetConversation_Call struct {
+	*mock.Call
+}
+
+// ResetConversation is a helper method to define mock.On call
+//   - ctx context.Context
+//   - chatID string
+func (_e *MockAIProvider_Expecter) ResetConversation(ctx interface{}, chatID interface{}) *MockAIProvider_ResetConversation_Call {
+	return &MockAIProvider_ResetConversation_Call{Call: _e.mock.On("ResetConversation", ctx, chatID)}
+}
+
+func (_c *MockAIProvider_ResetConversation_Call) Run(run func(ctx context.Context, chatID string)) *MockAIProvider_ResetConversation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockAIProvider_ResetConversation_Call) Return(_a0 error) *MockAIProvider_ResetConversation_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockAIProvider_ResetConversation_Call) RunAndReturn(run func(context.Context, string) error) *MockAIProvider_ResetConversation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockAIProvider creates a new instance of MockAIProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockAIProvider(t interface {

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -31,6 +31,12 @@ func (s *ServiceImpl) HandleCommand(ctx context.Context, msg *tgbotapi.Message) 
 		}
 
 		return tgbotapi.NewMessage(msg.Chat.ID, resp.Message), nil
+	case "cancel":
+		if err := s.AISvc.ResetConversation(ctx, fmt.Sprintf("%d", msg.Chat.ID)); err != nil {
+			return tgbotapi.MessageConfig{}, fmt.Errorf("failed to reset conversation: %w", err)
+		}
+
+		return tgbotapi.NewMessage(msg.Chat.ID, i18n.GetLocale(ctx).Sprintf("Questionary is cancelled")), nil
 	default:
 		return tgbotapi.NewMessage(msg.Chat.ID, i18n.GetLocale(ctx).Sprintf("Unknown command")), nil
 	}

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -32,7 +32,7 @@ func (s *ServiceImpl) HandleCommand(ctx context.Context, msg *tgbotapi.Message) 
 
 		return tgbotapi.NewMessage(msg.Chat.ID, resp.Message), nil
 	case "cancel":
-		if err := s.AISvc.ResetConversation(ctx, fmt.Sprintf("%d", msg.Chat.ID)); err != nil {
+		if err := s.AISvc.CancelQuestionnaire(ctx, fmt.Sprintf("%d", msg.Chat.ID)); err != nil {
 			return tgbotapi.MessageConfig{}, fmt.Errorf("failed to reset conversation: %w", err)
 		}
 

--- a/pkg/bot/commands_test.go
+++ b/pkg/bot/commands_test.go
@@ -76,6 +76,28 @@ func TestHandleCommand(t *testing.T) {
 			mockSetup:    func(m *MockAIProvider) {},
 			expectedMsg:  "Unknown command",
 		},
+		{
+			name:         "cancel command success",
+			command:      "/cancel",
+			languageCode: "en",
+			chatID:       123,
+			userID:       456,
+			mockSetup: func(m *MockAIProvider) {
+				m.EXPECT().CancelQuestionnaire(mock.Anything, "123").Return(nil)
+			},
+			expectedMsg: "Questionary is cancelled",
+		},
+		{
+			name:         "cancel command error",
+			command:      "/cancel",
+			languageCode: "en",
+			chatID:       123,
+			userID:       456,
+			mockSetup: func(m *MockAIProvider) {
+				m.EXPECT().CancelQuestionnaire(mock.Anything, "123").Return(assert.AnError)
+			},
+			expectedError: fmt.Errorf("failed to reset conversation: %w", assert.AnError),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/bot/service.go
+++ b/pkg/bot/service.go
@@ -31,6 +31,7 @@ type BotAPI interface {
 type AIProvider interface {
 	ProcessMessage(ctx context.Context, request *message.UserMessage) (*message.Response, error)
 	ProcessEditProfile(ctx context.Context, request *message.UserMessage) (*message.Response, error)
+	ResetConversation(ctx context.Context, chatID string) error
 }
 
 type httpClient interface {

--- a/pkg/bot/service.go
+++ b/pkg/bot/service.go
@@ -31,7 +31,7 @@ type BotAPI interface {
 type AIProvider interface {
 	ProcessMessage(ctx context.Context, request *message.UserMessage) (*message.Response, error)
 	ProcessEditProfile(ctx context.Context, request *message.UserMessage) (*message.Response, error)
-	ResetConversation(ctx context.Context, chatID string) error
+	CancelQuestionnaire(ctx context.Context, chatID string) error
 }
 
 type httpClient interface {

--- a/pkg/core/ai_service.go
+++ b/pkg/core/ai_service.go
@@ -33,7 +33,7 @@ type Conversation interface {
 	GetCurrentQuestion() (*message.Question, error)
 	AddQuestionAnswer(answer string) (bool, error)
 	GetQuestionnaireResult() ([]conversation.QuestionAnswer, error)
-	Reset()
+	CancelQuestionnaire()
 }
 
 // ConversationRepository defines the interface for conversation storage operations.

--- a/pkg/core/ai_service.go
+++ b/pkg/core/ai_service.go
@@ -33,6 +33,7 @@ type Conversation interface {
 	GetCurrentQuestion() (*message.Question, error)
 	AddQuestionAnswer(answer string) (bool, error)
 	GetQuestionnaireResult() ([]conversation.QuestionAnswer, error)
+	Reset()
 }
 
 // ConversationRepository defines the interface for conversation storage operations.

--- a/pkg/core/conversation/conversation.go
+++ b/pkg/core/conversation/conversation.go
@@ -207,6 +207,12 @@ func (c *Conversation) GetQuestionnaireResult() ([]QuestionAnswer, error) {
 	}
 }
 
+// Reset resets the conversation state to normal
+func (c *Conversation) Reset() {
+	c.State = StateNormal
+	c.Questionnaire = nil
+}
+
 // Unmarshal parses the JSON-encoded data and returns a new conversation.
 func Unmarshal(data []byte) (*Conversation, error) {
 	var tmpConv struct {

--- a/pkg/core/conversation/conversation.go
+++ b/pkg/core/conversation/conversation.go
@@ -207,8 +207,8 @@ func (c *Conversation) GetQuestionnaireResult() ([]QuestionAnswer, error) {
 	}
 }
 
-// Reset resets the conversation state to normal
-func (c *Conversation) Reset() {
+// CancelQuestionnaire resets the conversation state to normal
+func (c *Conversation) CancelQuestionnaire() {
 	c.State = StateNormal
 	c.Questionnaire = nil
 }

--- a/pkg/core/conversation/conversation_test.go
+++ b/pkg/core/conversation/conversation_test.go
@@ -503,3 +503,14 @@ func TestConversationUnmarshal_UnknownState(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, conv)
 }
+
+func TestConversationReset(t *testing.T) {
+	conv := NewConversation("test-GetID")
+	conv.State = StatePetProfileQuestioning
+	conv.Questionnaire = &PetProfileStateImpl{}
+
+	conv.Reset()
+
+	assert.Equal(t, StateNormal, conv.State)
+	assert.Nil(t, conv.Questionnaire)
+}

--- a/pkg/core/conversation/conversation_test.go
+++ b/pkg/core/conversation/conversation_test.go
@@ -509,7 +509,7 @@ func TestConversationReset(t *testing.T) {
 	conv.State = StatePetProfileQuestioning
 	conv.Questionnaire = &PetProfileStateImpl{}
 
-	conv.Reset()
+	conv.CancelQuestionnaire()
 
 	assert.Equal(t, StateNormal, conv.State)
 	assert.Nil(t, conv.Questionnaire)

--- a/pkg/core/conversation_mock.go
+++ b/pkg/core/conversation_mock.go
@@ -366,6 +366,38 @@ func (_c *MockConversation_History_Call) RunAndReturn(run func(int) string) *Moc
 	return _c
 }
 
+// Reset provides a mock function with no fields
+func (_m *MockConversation) Reset() {
+	_m.Called()
+}
+
+// MockConversation_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
+type MockConversation_Reset_Call struct {
+	*mock.Call
+}
+
+// Reset is a helper method to define mock.On call
+func (_e *MockConversation_Expecter) Reset() *MockConversation_Reset_Call {
+	return &MockConversation_Reset_Call{Call: _e.mock.On("Reset")}
+}
+
+func (_c *MockConversation_Reset_Call) Run(run func()) *MockConversation_Reset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockConversation_Reset_Call) Return() *MockConversation_Reset_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockConversation_Reset_Call) RunAndReturn(run func()) *MockConversation_Reset_Call {
+	_c.Run(run)
+	return _c
+}
+
 // StartFollowUpQuestions provides a mock function with given fields: initialPrompt, questions
 func (_m *MockConversation) StartFollowUpQuestions(initialPrompt string, questions []message.Question) error {
 	ret := _m.Called(initialPrompt, questions)

--- a/pkg/core/conversation_mock.go
+++ b/pkg/core/conversation_mock.go
@@ -116,6 +116,38 @@ func (_c *MockConversation_AddQuestionAnswer_Call) RunAndReturn(run func(string)
 	return _c
 }
 
+// CancelQuestionnaire provides a mock function with no fields
+func (_m *MockConversation) CancelQuestionnaire() {
+	_m.Called()
+}
+
+// MockConversation_CancelQuestionnaire_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CancelQuestionnaire'
+type MockConversation_CancelQuestionnaire_Call struct {
+	*mock.Call
+}
+
+// CancelQuestionnaire is a helper method to define mock.On call
+func (_e *MockConversation_Expecter) CancelQuestionnaire() *MockConversation_CancelQuestionnaire_Call {
+	return &MockConversation_CancelQuestionnaire_Call{Call: _e.mock.On("CancelQuestionnaire")}
+}
+
+func (_c *MockConversation_CancelQuestionnaire_Call) Run(run func()) *MockConversation_CancelQuestionnaire_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockConversation_CancelQuestionnaire_Call) Return() *MockConversation_CancelQuestionnaire_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockConversation_CancelQuestionnaire_Call) RunAndReturn(run func()) *MockConversation_CancelQuestionnaire_Call {
+	_c.Run(run)
+	return _c
+}
+
 // GetCurrentQuestion provides a mock function with no fields
 func (_m *MockConversation) GetCurrentQuestion() (*message.Question, error) {
 	ret := _m.Called()
@@ -363,38 +395,6 @@ func (_c *MockConversation_History_Call) Return(_a0 string) *MockConversation_Hi
 
 func (_c *MockConversation_History_Call) RunAndReturn(run func(int) string) *MockConversation_History_Call {
 	_c.Call.Return(run)
-	return _c
-}
-
-// Reset provides a mock function with no fields
-func (_m *MockConversation) Reset() {
-	_m.Called()
-}
-
-// MockConversation_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
-type MockConversation_Reset_Call struct {
-	*mock.Call
-}
-
-// Reset is a helper method to define mock.On call
-func (_e *MockConversation_Expecter) Reset() *MockConversation_Reset_Call {
-	return &MockConversation_Reset_Call{Call: _e.mock.On("Reset")}
-}
-
-func (_c *MockConversation_Reset_Call) Run(run func()) *MockConversation_Reset_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockConversation_Reset_Call) Return() *MockConversation_Reset_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockConversation_Reset_Call) RunAndReturn(run func()) *MockConversation_Reset_Call {
-	_c.Run(run)
 	return _c
 }
 

--- a/pkg/core/handlers.go
+++ b/pkg/core/handlers.go
@@ -30,6 +30,24 @@ func (s *AIService) ProcessMessage(ctx context.Context, request *message.UserMes
 	}
 }
 
+// ResetConversation resets the conversation state for the given chatID, clearing any prior messages or context.
+// It retrieves or creates the conversation for the chatID, resets it, and saves the updated state to the repository.
+// Returns an error if retrieval or saving of the conversation fails.
+func (s *AIService) ResetConversation(ctx context.Context, chatID string) error {
+	conv, err := s.repo.FindOrCreate(ctx, chatID)
+	if err != nil {
+		return fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	conv.Reset()
+
+	if err := s.repo.Save(ctx, conv); err != nil {
+		return fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return nil
+}
+
 // handleNewQuestion processes a new question from the user
 func (s *AIService) handleNewQuestion(ctx context.Context, conv Conversation, request *message.UserMessage) (*message.Response, error) {
 	// Check rate limit for new questions

--- a/pkg/core/handlers.go
+++ b/pkg/core/handlers.go
@@ -33,13 +33,13 @@ func (s *AIService) ProcessMessage(ctx context.Context, request *message.UserMes
 // ResetConversation resets the conversation state for the given chatID, clearing any prior messages or context.
 // It retrieves or creates the conversation for the chatID, resets it, and saves the updated state to the repository.
 // Returns an error if retrieval or saving of the conversation fails.
-func (s *AIService) ResetConversation(ctx context.Context, chatID string) error {
+func (s *AIService) CancelQuestionnaire(ctx context.Context, chatID string) error {
 	conv, err := s.repo.FindOrCreate(ctx, chatID)
 	if err != nil {
 		return fmt.Errorf("failed to get conversation: %w", err)
 	}
 
-	conv.Reset()
+	conv.CancelQuestionnaire()
 
 	if err := s.repo.Save(ctx, conv); err != nil {
 		return fmt.Errorf("failed to save conversation: %w", err)

--- a/pkg/core/handlers.go
+++ b/pkg/core/handlers.go
@@ -30,9 +30,9 @@ func (s *AIService) ProcessMessage(ctx context.Context, request *message.UserMes
 	}
 }
 
-// ResetConversation resets the conversation state for the given chatID, clearing any prior messages or context.
-// It retrieves or creates the conversation for the chatID, resets it, and saves the updated state to the repository.
-// Returns an error if retrieval or saving of the conversation fails.
+// CancelQuestionnaire cancels the active questionnaire for the specified chat ID.
+// It retrieves or initializes the conversation, updates its state, and persists the changes to the repository.
+// Returns error if retrieving or saving the conversation fails.
 func (s *AIService) CancelQuestionnaire(ctx context.Context, chatID string) error {
 	conv, err := s.repo.FindOrCreate(ctx, chatID)
 	if err != nil {

--- a/pkg/core/handlers_test.go
+++ b/pkg/core/handlers_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCancelQuestionnaire(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*MockConversationRepository, *MockConversation)
+		expectedError error
+	}{
+		{
+			name: "successful cancellation",
+			setupMocks: func(repoMock *MockConversationRepository, convMock *MockConversation) {
+				repoMock.EXPECT().FindOrCreate(mock.Anything, "chat123").Return(convMock, nil)
+				convMock.EXPECT().CancelQuestionnaire().Return()
+				repoMock.EXPECT().Save(mock.Anything, convMock).Return(nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "find or create fails",
+			setupMocks: func(repoMock *MockConversationRepository, _ *MockConversation) {
+				repoMock.EXPECT().FindOrCreate(mock.Anything, "chat123").Return(nil, assert.AnError)
+			},
+			expectedError: fmt.Errorf("failed to get conversation: %w", assert.AnError),
+		},
+		{
+			name: "save conversation fails",
+			setupMocks: func(repoMock *MockConversationRepository, convMock *MockConversation) {
+				repoMock.EXPECT().FindOrCreate(mock.Anything, "chat123").Return(convMock, nil)
+				convMock.EXPECT().CancelQuestionnaire().Return()
+				repoMock.EXPECT().Save(mock.Anything, convMock).Return(assert.AnError)
+			},
+			expectedError: fmt.Errorf("failed to save conversation: %w", assert.AnError),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			ctx := context.Background()
+			repoMock := NewMockConversationRepository(t)
+			convMock := NewMockConversation(t)
+			tt.setupMocks(repoMock, convMock)
+
+			service := &AIService{
+				repo: repoMock,
+			}
+
+			// Act
+			err := service.CancelQuestionnaire(ctx, "chat123")
+
+			// Assert
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			repoMock.AssertExpectations(t)
+			convMock.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
### Description

- Introduced a `Reset` method to clear conversation state and questionnaire.
- Added support for the "cancel" command to reset conversations.
- Implemented test cases and mock methods for the new functionality.
