### PR TITLE
Fix age calculation

### DIFF
--- a/pkg/core/pet/profile.go
+++ b/pkg/core/pet/profile.go
@@ -2,6 +2,7 @@ package pet
 
 import (
 	"fmt"
+	"time"
 )
 
 // Profile represents a pet's profile information
@@ -24,13 +25,34 @@ type Profiles struct {
 // This method is safe to use with partially filled Profile instances, as it handles empty or missing fields gracefully.
 // Returns a string representation of the Profile.
 func (p Profile) String() string {
+	age := calculateAge(p.DateOfBirth)
+
 	return fmt.Sprintf(`
 Pet Profile:
 Name: %s
 Species: %s
 Breed: %s
 Date of Birth: %s
+Age in years: %s
 Gender: %s
 Weight: %s
-`, p.Name, p.Species, p.Breed, p.DateOfBirth, p.Gender, p.Weight)
+`, p.Name, p.Species, p.Breed, p.DateOfBirth, age, p.Gender, p.Weight)
+}
+
+// calculateAge calculates the age in years based on the provided date of birth string in "YYYY-MM-DD" format.
+// It handles invalid input by returning "Not provided" and assumes the input string is correctly formatted.
+// Returns the age as a string or "Not provided" in case of an error during parsing.
+func calculateAge(dateOfBirth string) string {
+	dob, err := time.Parse("2006-01-02", dateOfBirth)
+	if err != nil {
+		return "Not provided"
+	}
+
+	now := time.Now()
+	age := now.Year() - dob.Year()
+	if now.YearDay() < dob.YearDay() {
+		age--
+	}
+
+	return fmt.Sprintf("%d", age)
 }

--- a/pkg/core/pet/profile.go
+++ b/pkg/core/pet/profile.go
@@ -25,7 +25,7 @@ type Profiles struct {
 // This method is safe to use with partially filled Profile instances, as it handles empty or missing fields gracefully.
 // Returns a string representation of the Profile.
 func (p Profile) String() string {
-	age := calculateAge(p.DateOfBirth)
+	age := calculateAge(time.Now(), p.DateOfBirth)
 
 	return fmt.Sprintf(`
 Pet Profile:
@@ -33,7 +33,7 @@ Name: %s
 Species: %s
 Breed: %s
 Date of Birth: %s
-Age in years: %s
+Age: %s
 Gender: %s
 Weight: %s
 `, p.Name, p.Species, p.Breed, p.DateOfBirth, age, p.Gender, p.Weight)
@@ -42,16 +42,23 @@ Weight: %s
 // calculateAge calculates the age in years based on the provided date of birth string in "YYYY-MM-DD" format.
 // It handles invalid input by returning "Not provided" and assumes the input string is correctly formatted.
 // Returns the age as a string or "Not provided" in case of an error during parsing.
-func calculateAge(dateOfBirth string) string {
+func calculateAge(now time.Time, dateOfBirth string) string {
 	dob, err := time.Parse("2006-01-02", dateOfBirth)
 	if err != nil {
 		return "Not provided"
 	}
 
-	now := time.Now()
 	age := now.Year() - dob.Year()
 	if now.YearDay() < dob.YearDay() {
 		age--
+	}
+
+	if age < 0 {
+		return "Not provided"
+	}
+
+	if age == 0 {
+		return "Less than a year"
 	}
 
 	return fmt.Sprintf("%d", age)

--- a/pkg/core/pet/profile_test.go
+++ b/pkg/core/pet/profile_test.go
@@ -2,7 +2,66 @@ package pet
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestCalculateAge(t *testing.T) {
+	tests := []struct {
+		name        string
+		now         time.Time
+		dateOfBirth string
+		expectedAge string
+		expectedErr bool
+	}{
+		{
+			name:        "Valid age calculation",
+			now:         time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+			dateOfBirth: "2000-01-01",
+			expectedAge: "23",
+			expectedErr: false,
+		},
+		{
+			name:        "Date of birth in the future",
+			now:         time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+			dateOfBirth: "2025-01-01",
+			expectedAge: "Not provided",
+			expectedErr: false,
+		},
+		{
+			name:        "Invalid date format",
+			now:         time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+			dateOfBirth: "01-01-2000",
+			expectedAge: "Not provided",
+			expectedErr: false,
+		},
+		{
+			name:        "Age less than a year",
+			now:         time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+			dateOfBirth: "2023-06-01",
+			expectedAge: "Less than a year",
+			expectedErr: false,
+		},
+		{
+			name:        "Empty date of birth",
+			now:         time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
+			dateOfBirth: "",
+			expectedAge: "Not provided",
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			result := calculateAge(tt.now, tt.dateOfBirth)
+
+			// Assert
+			assert.Equal(t, tt.expectedAge, result)
+		})
+	}
+}
 
 func TestPetProfile_String(t *testing.T) {
 	tests := []struct {
@@ -26,6 +85,7 @@ Name: Buddy
 Species: Dog
 Breed: Golden Retriever
 Date of Birth: 2018-05-10
+Age: 6
 Gender: Male
 Weight: 30.5
 `,
@@ -46,6 +106,7 @@ Name:
 Species: 
 Breed: 
 Date of Birth: 
+Age: Not provided
 Gender: 
 Weight: 
 `,
@@ -63,6 +124,7 @@ Name: Whiskers
 Species: Cat
 Breed: 
 Date of Birth: 
+Age: Not provided
 Gender: 
 Weight: 4.2
 `,
@@ -78,6 +140,7 @@ Name:
 Species: 
 Breed: 
 Date of Birth: 2020-07-15
+Age: 4
 Gender: 
 Weight: 
 `,
@@ -94,6 +157,7 @@ Name: Tiny
 Species: 
 Breed: 
 Date of Birth: 
+Age: Not provided
 Gender: 
 Weight: -1.5
 `,


### PR DESCRIPTION

### Description
This pull request introduces the following changes:

- Refactored `calculateAge` function to improve logic, enable future-oriented tests by accepting the current time as a parameter, and handle edge cases such as future dates, invalid formats, and ages under one year.
- Integrated the `calculateAge` function into the `String` method of the pet profile, appending the calculated age to the string representation.
- Ensured robust handling for invalid or missing date of birth by defaulting to "Not provided."
- Added comprehensive unit tests to validate various scenarios for age calculation, ensuring accuracy and handling edge cases reliably.
  
These updates improve the representation of pet profiles and ensure consistency in handling date-dependent logic