### PR TITLE
Remove reply keyboard on questionary cancellation  

### DIFF
--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -36,7 +36,14 @@ func (s *ServiceImpl) HandleCommand(ctx context.Context, msg *tgbotapi.Message) 
 			return tgbotapi.MessageConfig{}, fmt.Errorf("failed to reset conversation: %w", err)
 		}
 
-		return tgbotapi.NewMessage(msg.Chat.ID, i18n.GetLocale(ctx).Sprintf("Questionary is cancelled")), nil
+		resp := tgbotapi.NewMessage(msg.Chat.ID, i18n.GetLocale(ctx).Sprintf("Questionary is cancelled"))
+
+		resp.ReplyMarkup = tgbotapi.ReplyKeyboardRemove{
+			RemoveKeyboard: true,
+			Selective:      false,
+		}
+
+		return resp, nil
 	case "help":
 		return handleHelp(ctx, msg)
 	default:


### PR DESCRIPTION
**Description:**  

### Summary  
This update ensures that the reply keyboard is removed when the questionary is cancelled. It enhances user experience by preventing the keyboard from lingering unnecessarily after the action is completed.  

### Changes  
- Reply keyboard is disabled upon questionary cancellation.  
