### PR TITLE
Increase global daily request limit to 4000

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ ai:
 rate_limit:
   user_hourly_limit: 5  # Maximum number of requests per hour per user
   user_daily_limit: 15  # Maximum number of requests per day per user
-  global_daily_limit: 1000  # Maximum total requests per day across all users
+  global_daily_limit: 4000  # Maximum total requests per day across all users
   whitelist_ids: [] # List of user IDs exempt from rate limiting
 
 bot:


### PR DESCRIPTION
### Description of Changes

- Updated the global daily request limit from 1000 to 4000 in the rate-limiting configuration.  
- Allows for higher usage scenarios by accommodating increased overall daily requests.

