### PR TITLE
Update Go to 1.24.1 and dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.23.4"]
+        go-version: ["1.24.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
@@ -27,7 +27,7 @@ jobs:
       - name: Code Lint
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea
         with:
-          version: v1.63.1
+          version: v1.64.7
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG VERSION=${VERSION}
 ARG BUILD=${BUILD}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/help-my-pet
 
-go 1.23.4
+go 1.24.1
 
 require (
 	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.13


### PR DESCRIPTION
### Description

- Upgraded Go version to 1.24.1 in `workflow`, `go.mod`, and `Dockerfile` for compatibility with the latest enhancements and bug fixes.
- Updated `golangci-lint` to v1.64.7 in the CI pipeline for improved linting and code quality checks.
- Aimed to ensure stability and maintain adherence to current development standards