### PR TITLE
Upgrade anthropic-sdk-go to v1.2.0 for compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ksysoev/help-my-pet
 go 1.24.1
 
 require (
-	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
+	github.com/anthropics/anthropic-sdk-go v1.2.0
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3 h1:b5t1ZJMvV/l99y4jbz7kRFdUp3BSDkI8EhSlHczivtw=
 github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3/go.mod h1:AapDW22irxK2PSumZiQXYUFvsdQgkwIWlpESweWZI/c=
+github.com/anthropics/anthropic-sdk-go v1.2.0 h1:RQzJUqaROewrPTl7Rl4hId/TqmjFvfnkmhHJ6pP1yJ8=
+github.com/anthropics/anthropic-sdk-go v1.2.0/go.mod h1:AapDW22irxK2PSumZiQXYUFvsdQgkwIWlpESweWZI/c=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/pkg/prov/anthropic/model.go
+++ b/pkg/prov/anthropic/model.go
@@ -88,7 +88,7 @@ func (m *anthropicModel) Call(ctx context.Context, systemPrompts, request string
 	}
 
 	msg, err := m.client.Messages.New(ctx, anthropic.MessageNewParams{
-		Model:     m.modelID,
+		Model:     anthropic.Model(m.modelID),
 		MaxTokens: int64(m.maxTokens),
 		System: []anthropic.TextBlockParam{
 			{Text: coreGuidelines},


### PR DESCRIPTION
Updated the anthropic-sdk-go dependency to version 1.2.0 in `go.mod` and `go.sum`. Adjusted type casting in `model.go` to align with changes in the new SDK version. This ensures improved compatibility and access to the latest features of the SDK.